### PR TITLE
Adding Support for longer domains

### DIFF
--- a/DIY/Firewall/Scripts/WorkshopStep1.ps1
+++ b/DIY/Firewall/Scripts/WorkshopStep1.ps1
@@ -68,7 +68,7 @@ Write-Host "  Current Sub:",$myContext.Subscription.Name,"(",$myContext.Subscrip
 
 Write-Host (Get-Date)' - ' -NoNewline
 Write-Host "  Checking Login" -ForegroundColor Cyan
-$RegEx = '^([\w-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([\w-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$'
+$RegEx = '^([\w-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([\w-]+\.)+))([a-zA-Z]{2,5}|[0-9]{1,3})(\]?)$'
 If ($myContext.Account.Id -notmatch $RegEx) {
         Write-Host "Fatal Error: You are logged in with a Managed Service bearer token" -ForegroundColor Red
         Write-Host "To correct this, you'll need to login using your Azure credentials."


### PR DESCRIPTION
The current Regex looks for domain names ranging from 2-4 characters. If you attempt to run the script with a .cloud extension then the Regex fails. This updates the Regex to support 5 characters.